### PR TITLE
Change shelter id used in test to be valid

### DIFF
--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -106,7 +106,7 @@ class ShelterTests(BaseCase):
         Tests the shelter_get() method.
         """
 
-        shelter = self.api.shelter_get(id='GA137')
+        shelter = self.api.shelter_get(id='GA251')
         self.assertIsInstance(shelter, dict)
         self.assertTrue(shelter.has_key('id'))
         self.assertTrue(shelter.has_key('name'))


### PR DESCRIPTION
The previous shelter id used in tests `GA137` looks to be invalid:

> api.shelter_get(id='GA137')
> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File "petfinder/client.py", line 332, in shelter_get
>     root = self._do_api_call("shelter.get", kwargs)
>   File "petfinder/client.py", line 87, in _do_api_call
>     raise exc_class(error_message)
> petfinder.exceptions.RecordDoesNotExistError: shelter id GA137 not found

changed to `GA251` which represents the Atlanta Humane Society.
